### PR TITLE
chore: add postinstall script prisma generate

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@heroicons/react": "2.1.1",


### PR DESCRIPTION
This pull request includes a small but important change to the `package.json` file. A new script command, `postinstall`, has been added to automatically generate Prisma client after each install. This will help to keep the Prisma client up-to-date with the Prisma schema.