### PR TITLE
chore: add vercel insight and analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@heroicons/react": "2.1.1",
     "@material-tailwind/react": "2.1.8",
     "@prisma/client": "5.8.1",
+    "@vercel/analytics": "1.1.2",
+    "@vercel/speed-insights": "1.0.8",
     "next": "14.1.0",
     "prisma": "5.8.1",
     "react": "18.2.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import './globals.css'
 import type { Metadata } from 'next'
 import { Roboto } from 'next/font/google'
 import { Layout, FixedPlugin } from '@/components'
+import { Analytics } from '@vercel/analytics/react'
+import { SpeedInsights } from '@vercel/speed-insights/next'
 
 const roboto = Roboto({
   subsets: ['latin'],
@@ -25,7 +27,7 @@ export default function RootLayout({
       <head>
         <script
           defer
-          data-site='YOUR_DOMAIN_HERE'
+          data-site='jegat-dasilva.fr'
           src='https://api.nepcha.com/js/nepcha-analytics.js'
         ></script>
         <link rel='shortcut icon' href='/favicon.png' type='image/png' />
@@ -42,6 +44,8 @@ export default function RootLayout({
           crossOrigin='anonymous'
           referrerPolicy='no-referrer'
         />
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   )


### PR DESCRIPTION
This pull request primarily focuses on enhancing the analytics and performance monitoring capabilities of the application. The changes include the addition of new dependencies in the `package.json` file, the integration of these dependencies in the `layout.tsx` file, and the update of the 'data-site' attribute in the analytics script tag.

* Dependency updates:

  * [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R19-R20): Added `@vercel/analytics` and `@vercel/speed-insights` packages to enhance the application's analytics and performance monitoring capabilities.

* Analytics and performance monitoring integration:

  * [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R5-R6): Imported `Analytics` and `SpeedInsights` from the newly added packages and used them in the `RootLayout` function to integrate analytics and performance monitoring into the application. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R5-R6) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R47-R48)

* Analytics script tag update:

  * [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L28-R30): Updated the 'data-site' attribute in the analytics script tag to 'jegat-dasilva.fr'.